### PR TITLE
Remove commit hash from `--version` output

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<Version>4.0.0</Version>
+		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<Copyright>Ivo Gomes © 2026. All Rights Reserved.</Copyright>
 	</PropertyGroup>
 


### PR DESCRIPTION
# Pull request

Thank you for contributing to Hashx.

Before submitting, ensure that the reviewers, assignees, labels and summary fields are filled appropriately.

## Summary

- Removes the commit hash from the `--version` option output for a cleaner display.